### PR TITLE
Rolling Terminal

### DIFF
--- a/src/monitor.asm
+++ b/src/monitor.asm
@@ -97,6 +97,9 @@ bmfs:
 	jmp poll
 
 poll:
+	mov rsi, newline
+	call ui_output
+poll_nonewline:
 	mov rsi, prompt
 	call ui_output
 	mov rdi, temp_string
@@ -176,7 +179,7 @@ exec:
 
 cls:
 	call screen_clear
-	jmp poll
+	jmp poll_nonewline
 
 dir:
 	mov al, [FSType]
@@ -876,7 +879,7 @@ hextable:		db '0123456789ABCDEF'
 
 ; Strings
 
-prompt:			db 13, '> ', 0
+prompt:			db '> ', 0
 message_ver:		db 13, '1.0', 0
 message_load:		db 13, 'Enter file number: ', 0
 message_unknown:	db 13, 'Unknown command', 0

--- a/src/monitor.asm
+++ b/src/monitor.asm
@@ -339,17 +339,17 @@ dump_b:
 	call ui_output
 	pop rsi
 	mov rax, rsi
-	call dump_rax
+	call dump_rax		; Display the memory address
 	push rsi
 	mov rsi, dumpsep
-	call ui_output
+	call ui_output		; Display ": "
 	pop rsi
 dump_b_next:
-	cmp dl, 0x10
-	je dump_b_newline
+	cmp dl, 0x10		; 16 bytes per line
+	je dump_b_newline	; Display a newline if we are over the limit
 	lodsb
-	call dump_al
-	inc dl
+	call dump_al		; Dump the byte
+	inc dl			; Increment our counter of values per line
 	push rsi
 	mov rsi, space
 	call ui_output
@@ -358,9 +358,7 @@ dump_b_next:
 	jnz dump_b_next
 	jmp dump_end
 dump_b_newline:
-	xor edx, edx
-	cmp rcx, 0
-	jz dump_end
+	xor edx, edx		; Reset the value counter
 	jmp dump_b
 
 dump_w:
@@ -375,7 +373,7 @@ dump_w:
 	call ui_output
 	pop rsi
 dump_w_next:
-	cmp dl, 0x8
+	cmp dl, 0x8		; 8 words per line
 	je dump_w_newline
 	lodsw
 	call dump_ax
@@ -389,8 +387,6 @@ dump_w_next:
 	jmp dump_end
 dump_w_newline:
 	xor edx, edx
-	cmp rcx, 0
-	jz dump_end
 	jmp dump_w
 
 dump_d:
@@ -405,7 +401,7 @@ dump_d:
 	call ui_output
 	pop rsi
 dump_d_next:
-	cmp dl, 0x4
+	cmp dl, 0x4		; 4 double words per line
 	je dump_d_newline
 	lodsd
 	call dump_eax
@@ -419,8 +415,6 @@ dump_d_next:
 	jmp dump_end
 dump_d_newline:
 	xor edx, edx
-	cmp rcx, 0
-	jz dump_end
 	jmp dump_d
 
 dump_q:
@@ -435,7 +429,7 @@ dump_q:
 	call ui_output
 	pop rsi
 dump_q_next:
-	cmp dl, 0x2
+	cmp dl, 0x2		; 2 quad words per line
 	je dump_q_newline
 	lodsq
 	call dump_rax
@@ -449,8 +443,6 @@ dump_q_next:
 	jmp dump_end
 dump_q_newline:
 	xor edx, edx
-	cmp rcx, 0
-	jz dump_end
 	jmp dump_q
 
 dump_end:

--- a/src/monitor.asm
+++ b/src/monitor.asm
@@ -319,6 +319,7 @@ dump:
 
 	mov rsi, r8
 	mov rcx, r9
+	xor edx, edx		; Counter for line output
 
 	cmp al, 1
 	je dump_b
@@ -337,25 +338,48 @@ dump_b:
 	mov rsi, newline
 	call ui_output
 	pop rsi
+	mov rax, rsi
+	call dump_rax
+	push rsi
+	mov rsi, dumpsep
+	call ui_output
+	pop rsi
 dump_b_next:
+	cmp dl, 0x10
+	je dump_b_newline
 	lodsb
 	call dump_al
+	inc dl
 	push rsi
 	mov rsi, space
 	call ui_output
 	pop rsi
-	dec rcx
+	dec rcx			; Decrement the number of bytes left to output
 	jnz dump_b_next
 	jmp dump_end
+dump_b_newline:
+	xor edx, edx
+	cmp rcx, 0
+	jz dump_end
+	jmp dump_b
 
 dump_w:
 	push rsi
 	mov rsi, newline
 	call ui_output
 	pop rsi
+	mov rax, rsi
+	call dump_rax
+	push rsi
+	mov rsi, dumpsep
+	call ui_output
+	pop rsi
 dump_w_next:
+	cmp dl, 0x8
+	je dump_w_newline
 	lodsw
 	call dump_ax
+	inc dl
 	push rsi
 	mov rsi, space
 	call ui_output
@@ -363,6 +387,11 @@ dump_w_next:
 	dec rcx
 	jnz dump_w_next
 	jmp dump_end
+dump_w_newline:
+	xor edx, edx
+	cmp rcx, 0
+	jz dump_end
+	jmp dump_w
 
 dump_d:
 	push rsi
@@ -375,11 +404,24 @@ dump_d:
 	mov rsi, dumpsep
 	call ui_output
 	pop rsi
+dump_d_next:
+	cmp dl, 0x4
+	je dump_d_newline
 	lodsd
 	call dump_eax
+	inc dl
+	push rsi
+	mov rsi, space
+	call ui_output
+	pop rsi
 	dec rcx
-	jnz dump_d
+	jnz dump_d_next
 	jmp dump_end
+dump_d_newline:
+	xor edx, edx
+	cmp rcx, 0
+	jz dump_end
+	jmp dump_d
 
 dump_q:
 	push rsi
@@ -392,11 +434,24 @@ dump_q:
 	mov rsi, dumpsep
 	call ui_output
 	pop rsi
+dump_q_next:
+	cmp dl, 0x2
+	je dump_q_newline
 	lodsq
 	call dump_rax
+	inc dl
+	push rsi
+	mov rsi, space
+	call ui_output
+	pop rsi
 	dec rcx
-	jnz dump_q
+	jnz dump_q_next
 	jmp dump_end
+dump_q_newline:
+	xor edx, edx
+	cmp rcx, 0
+	jz dump_end
+	jmp dump_q
 
 dump_end:
 	jmp poll

--- a/src/ui.asm
+++ b/src/ui.asm
@@ -64,7 +64,7 @@ ui_init:
 	mov ax, [VideoX]
 	mov cl, [font_width]
 	div cx				; Divide VideoX by font_width
-	sub ax, 2			; Subtract 2 for margin
+	sub ax, 2			; Subtract 2 for horizontal margin
 	mov [Screen_Cols], ax
 	xor eax, eax
 	xor edx, edx
@@ -72,7 +72,6 @@ ui_init:
 	mov ax, [VideoY]
 	mov cl, [font_height]
 	div cx				; Divide VideoY by font_height
-	sub ax, 2			; Subtrack 2 for margin
 	mov [Screen_Rows], ax
 
 	call screen_clear
@@ -344,7 +343,6 @@ load_char:
 	xor edx, edx
 	xor eax, eax
 	mov ax, [Screen_Cursor_Row]
-	add ax, 1
 	mov cx, 12			; Font height
 	mul cx
 	mov bx, ax
@@ -352,7 +350,7 @@ load_char:
 	xor edx, edx
 	xor eax, eax
 	mov ax, [Screen_Cursor_Col]
-	add ax, 1
+	add ax, 1			; Add offset by one char for horizontal margin
 	mov cx, 6			; Font width
 	mul cx
 	mov bx, ax
@@ -489,7 +487,7 @@ draw_line:
 	xor ecx, ecx
 	xor eax, eax
 	mov ax, [Screen_Cursor_Row]
-	add ax, 2
+	add ax, 1
 	mov cx, 48			; Font height
 	mul cx
 	mov cx, [VideoPPSL]
@@ -502,11 +500,11 @@ draw_line:
 	rep stosd
 
 ; Clear the next row of text
-	mov ax, [Screen_Cursor_Row]
-	inc ax
+	mov ax, [Screen_Cursor_Row]	; Get the currect cursor row
+	inc ax				; Inc by 1 as it is 0-based
 	cmp ax, [Screen_Rows]		; Compare it to the # of rows for the screen
 	jne draw_line_skip
-	mov rdi, [VideoBase]
+	mov rdi, [VideoBase]		; Roll RDI back to the start of video memory
 draw_line_skip:
 	xor eax, eax
 	mov ax, [VideoPPSL]

--- a/src/ui.asm
+++ b/src/ui.asm
@@ -461,6 +461,8 @@ screen_clear:
 	shr ecx, 2			; Quick divide by 4
 	rep stosd
 
+	call draw_line
+
 	pop rax
 	pop rcx
 	pop rdi
@@ -499,7 +501,13 @@ draw_line:
 	mov eax, 0x00F7CA54
 	rep stosd
 
-; Clear the whole next row of text
+; Clear the next row of text
+	mov ax, [Screen_Cursor_Row]
+	inc ax
+	cmp ax, [Screen_Rows]		; Compare it to the # of rows for the screen
+	jne draw_line_skip
+	mov rdi, [VideoBase]
+draw_line_skip:
 	xor eax, eax
 	mov ax, [VideoPPSL]
 	mov ecx, 12

--- a/src/ui.asm
+++ b/src/ui.asm
@@ -26,6 +26,7 @@ ui_init:
 	mov rcx, screen_lfb_get
 	call [b_config]
 	mov [VideoBase], rax
+	mov [LastLine], rax
 	xor eax, eax
 	mov rcx, screen_x_get
 	call [b_config]
@@ -74,31 +75,11 @@ ui_init:
 	sub ax, 2			; Subtrack 2 for margin
 	mov [Screen_Rows], ax
 
-	; Adjust the high memory map to keep 2MiB for the Frame Buffer
-	mov rsi, 0x20000
-	mov rdi, 0x20000
-	mov rcx, 4			; 8 MiB
-adjustnext:
-	lodsq				; Load a PDPE
-	add eax, 0x200000		; Add 2MiB to its base address
-	stosq				; Store it back
-	dec rcx
-	cmp rcx, 0
-	jne adjustnext
-	mov rcx, 4			; 8 MiB TODO Adjust for stack
-	xor eax, eax
-	rep stosq
-
 	call screen_clear
 
 	; Overwrite the kernel b_output function so output goes to the screen instead of the serial port
 	mov rax, output_chars
 	mov [0x100018], rax
-
-	; Move cursor to bottom of screen
-	mov ax, [Screen_Rows]
-	dec ax
-	mov [Screen_Cursor_Row], ax
 
 	pop rax
 	pop rcx
@@ -201,9 +182,7 @@ inc_cursor:
 	mov ax, [Screen_Cursor_Row]
 	cmp ax, [Screen_Rows]		; Compare it to the # of rows for the screen
 	jne inc_cursor_done		; If not equal we are done
-	call screen_scroll		; Otherwise scroll the screen
-	dec word [Screen_Cursor_Row]	; Decrement the current cursor row
-
+	mov word [Screen_Cursor_Row], 0
 inc_cursor_done:
 	pop rax
 	ret
@@ -217,14 +196,14 @@ inc_cursor_done:
 dec_cursor:
 	push rax
 
-	cmp word [Screen_Cursor_Col], 0
-	jne dec_cursor_done
-	dec word [Screen_Cursor_Row]
-	mov ax, [Screen_Cols]
+	cmp word [Screen_Cursor_Col], 0	; Compare the current cursor column to 0
+	jne dec_cursor_done		; If not equal we are done
+	dec word [Screen_Cursor_Row]	; Otherwise decrement the row
+	mov ax, [Screen_Cols]		; Get the total colums and save it as the current
 	mov word [Screen_Cursor_Col], ax
 
 dec_cursor_done:
-	dec word [Screen_Cursor_Col]
+	dec word [Screen_Cursor_Col]	; Decrement the cursor as usual
 
 	pop rax
 	ret
@@ -309,7 +288,7 @@ output_char:
 
 
 ; -----------------------------------------------------------------------------
-; output_newline -- Reset cursor to start of next line and scroll if needed
+; output_newline -- Reset cursor to start of next line and wrap if needed
 ;  IN:	Nothing
 ; OUT:	All registers preserved
 output_newline:
@@ -319,14 +298,15 @@ output_newline:
 	mov ax, [Screen_Rows]		; Grab max rows on screen
 	dec ax				; and subtract 1
 	cmp ax, [Screen_Cursor_Row]	; Is the cursor already on the bottom row?
-	je output_newline_scroll	; If so, then scroll
+	je output_newline_wrap		; If so, then wrap
 	inc word [Screen_Cursor_Row]	; If not, increment the cursor to next row
 	jmp output_newline_done
 
-output_newline_scroll:
-	call screen_scroll
+output_newline_wrap:
+	mov word [Screen_Cursor_Row], 0
 
 output_newline_done:
+	call draw_line
 	pop rax
 	ret
 ; -----------------------------------------------------------------------------
@@ -437,28 +417,6 @@ pixel:
 	push rbx
 	push rax
 
-	push rbx
-	push rax
-
-	; Calculate offset in frame buffer and store pixel
-	push rax			; Save the pixel details
-	mov rax, rbx
-	shr eax, 16			; Isolate Y co-ordinate
-	xor ecx, ecx
-	mov cx, [VideoX]
-	mul ecx				; Multiply Y by VideoX
-	and ebx, 0x0000FFFF		; Isolate X co-ordinate
-	add eax, ebx			; Add X
-	mov rbx, rax			; Save the offset to RBX
-	mov rdi, [FrameBuffer]		; Store the pixel to the frame buffer
-	pop rax				; Restore pixel details
-	shl ebx, 2			; Quickly multiply by 4
-	add rdi, rbx			; Add offset to frame buffer memory
-	stosd				; Output pixel to the frame buffer
-
-	pop rax
-	pop rbx
-
 	; Calculate offset in video memory and store pixel
 	push rax			; Save the pixel details
 	mov rax, rbx
@@ -485,41 +443,6 @@ pixel:
 
 
 ; -----------------------------------------------------------------------------
-; scroll_screen -- Scrolls the screen up by one line
-;  IN:	Nothing
-; OUT:	All registers preserved
-screen_scroll:
-	push rsi
-	push rdi
-	push rcx
-	push rax
-
-	xor eax, eax			; Calculate offset to bottom row
-	xor ecx, ecx
-	mov ax, [VideoX]
-	mov cl, [font_height]
-	mul ecx				; EAX = EAX * ECX
-	shl eax, 2			; Quick multiply by 4 for 32-bit colour depth
-
-	mov rdi, [FrameBuffer]
-	mov esi, [Screen_Row_2]
-	add rsi, rdi
-	mov ecx, [Screen_Bytes]
-	sub ecx, eax			; Subtract the offset
-	shr ecx, 2			; Quick divide by 4
-	rep movsd
-
-	call screen_update
-
-	pop rax
-	pop rcx
-	pop rdi
-	pop rsi
-	ret
-; -----------------------------------------------------------------------------
-
-
-; -----------------------------------------------------------------------------
 ; screen_clear -- Clear the screen
 ;  IN:	Nothing
 ; OUT:	All registers preserved
@@ -528,15 +451,15 @@ screen_clear:
 	push rcx
 	push rax
 
+	mov word [Screen_Cursor_Col], 0
+	mov word [Screen_Cursor_Row], 0
+
 	; Set the Frame Buffer to the background colour
-	mov rdi, [FrameBuffer]
+	mov rdi, [VideoBase]
 	mov eax, [BG_Color]
 	mov ecx, [Screen_Bytes]
 	shr ecx, 2			; Quick divide by 4
 	rep stosd
-
-	; Write the Frame Buffer to Video memory
-	call screen_update
 
 	pop rax
 	pop rcx
@@ -546,38 +469,47 @@ screen_clear:
 
 
 ; -----------------------------------------------------------------------------
-; screen_update -- Updates the screen from the frame buffer
-;  IN:	Nothing
-; OUT:	All registers preserved
-screen_update:
+; draw_line
+draw_line:
 	push rdi
-	push rsi
 	push rdx
 	push rcx
+	push rax
 
-	mov rsi, [FrameBuffer]
+; Clear the previously drawn line
+	mov rdi, [LastLine]
+	mov cx, [VideoPPSL]
+	mov eax, [BG_Color]
+	rep stosd
+
+; Display a line under the current cursor row
 	mov rdi, [VideoBase]
-	xor edx, edx
-	mov dx, [VideoY]
-
-screen_update_line:
 	xor ecx, ecx
-	mov cx, [VideoX]
-	rep movsd			; Only copy visible pixels
-	dec edx
-	jz screen_update_done
+	xor eax, eax
+	mov ax, [Screen_Cursor_Row]
+	add ax, 2
+	mov cx, 48			; Font height
+	mul cx
+	mov cx, [VideoPPSL]
+	mul ecx				; Multiply Y by VideoPPSL
+	add rdi, rax
+	mov [LastLine], rdi
 	xor ecx, ecx
-	mov cx, [VideoX]
-	shl ecx, 2			; Quick multiply by 4
-	sub rdi, rcx
-	mov ecx, [VideoPPSL]
-	shl ecx, 2			; Quick multiply by 4
-	add rdi, rcx
-	jmp screen_update_line
+	mov cx, [VideoPPSL]
+	mov eax, 0x00F7CA54
+	rep stosd
 
-screen_update_done:
+; Clear the whole next row of text
+	xor eax, eax
+	mov ax, [VideoPPSL]
+	mov ecx, 12
+	mul ecx
+	mov ecx, eax
+	mov eax, [BG_Color]
+	rep stosd
+
+	pop rax
 	pop rcx
-	pop rsi
 	pop rdx
 	pop rdi
 	ret
@@ -613,7 +545,7 @@ string_length:
 align 16
 
 VideoBase:		dq 0
-FrameBuffer:		dq 0x0000000000200000
+LastLine:		dq 0
 FG_Color:		dd 0x00FFFFFF
 BG_Color:		dd 0x00404040
 Screen_Pixels:		dd 0


### PR DESCRIPTION
Unconventional but much faster. This also removes the need for a frame buffer.
Also cleaned up the output of the `dump` command