### PR TITLE
Add flag for NASM v3+

### DIFF
--- a/src/monitor.asm
+++ b/src/monitor.asm
@@ -9,6 +9,7 @@
 
 BITS 64
 ORG 0x001E0000
+DEFAULT ABS
 MONITORSIZE equ 6144			; Pad Monitor to this length
 
 %include 'api/libBareMetal.asm'


### PR DESCRIPTION
This pull request makes a small change to the `src/monitor.asm` file, adding the `DEFAULT ABS` directive to the assembly source. This can help clarify addressing mode for the assembler.